### PR TITLE
Repository Detail Page

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -100,6 +100,10 @@ program
               map: 'function(doc) { emit([doc.repository_url, doc.date_received.substring(0, 4), doc.date_received.substring(5, 7), doc.date_received.substring(8, 10), doc.space_id, doc.application_version]); }',
               reduce: '_count',
             },
+            by_repo_hash: {
+              map: 'function(doc) { emit([doc.repository_url_hash, doc.repository_url, doc.date_received.substring(0, 4), doc.date_received.substring(5, 7), doc.date_received.substring(8, 10), doc.space_id, doc.application_version]); }',
+              reduce: '_count',
+            },
             apps_by_year_and_month: {
               map: 'function(doc) { emit([doc.date_received.substring(0, 4), doc.date_received.substring(5, 7), doc.repository_url, doc.space_id, doc.application_version]); }',
               reduce: '_count',

--- a/app.js
+++ b/app.js
@@ -127,6 +127,9 @@ app.get('/stats', authenticate(), function(req, res) {
           url: url,
           count: 0
         };
+        if (url) {
+          apps[url].url_hash = crypto.createHash('md5').update(url).digest('hex');
+        }
       }
       if (validator.isURL(url, {protocols: ['http','https'], require_protocol: true})) {
         apps[url].is_url = true;

--- a/app.js
+++ b/app.js
@@ -171,7 +171,7 @@ app.get('/stats/:hash', authenticate(), function(req, res) {
   eventsDb.view('deployments', 'by_repo_hash', {startkey: [hash], endkey: [hash, {}, {}, {}, {}, {}, {}], group_level: 4}, function(err, body) {
     var apps = {};
     body.rows.map(function(row) {
-      var hash = row.key[0]
+      var hash = row.key[0];
       var url = row.key[1];
       var year = row.key[2];
       var month = row.key[3];

--- a/app.js
+++ b/app.js
@@ -16,7 +16,8 @@ var express = require('express'),
     sessionStore = new expressSession.MemoryStore(),
     _ = require("underscore"),
     uuid = require('node-uuid'),
-    forceSSL = require('express-force-ssl');
+    forceSSL = require('express-force-ssl'),
+    crypto = require('crypto');
 
 
 dotenv.load();
@@ -179,6 +180,7 @@ function track(req, res) {
   }
   if (req.body.repository_url) {
     event.repository_url = req.body.repository_url;
+    event.repository_url_hash = crypto.createHash('md5').update(event.repository_url).digest('hex');
   }
   if (req.body.application_name) {
     event.application_name = req.body.application_name;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "./admin.js track && ./admin.js db put && ./admin.js ddoc put",
+    "postinstall": "./admin.js track && ./admin.js db put && ./admin.js ddoc put && ./admin.js clean repository_url_hash",
     "start": "node app.js",
     "test": "grunt"
   },

--- a/views/repo.html
+++ b/views/repo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Deployment Tracker</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+    <div class="jumbotron">
+      <div class="container">
+        <h1>Deployment Tracker</h1>
+        <p>Deployments of sample applications to <a href="https://www.bluemix.net/">IBM Bluemix</a></p>
+        <p><a class="btn btn-primary btn-lg" href="https://github.com/IBM-Bluemix/cf-deployment-tracker-service" target="_blank" role="button">View the source code on GitHub <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a></p>
+      </div>
+    </div>
+    <article class="container">
+      <h1>Application Deployments by Repository</h1>
+{{#each apps}}
+      <section>
+        <h2>{{#if url}}{{#if is_url}}<a href="{{url}}" target="_blank" aria-hidden="true">{{url}}</a>{{else}}{{url}}{{/if}}{{else}}<em>No repository URL</em>{{/if}}{{#if url_hash}} <a href="/stats/{{url_hash}}"><span class="glyphicon glyphicon-bookmark" aria-hidden="true"></span></a>{{/if}} <span class="badge">{{count}}</span></h2>
+        <ul class="list-group">
+{{#each this}}
+{{#each this}}
+          <li class="list-group-item">
+            <span class="badge">{{this}}</span>
+            {{@../key}}-{{@key}}
+          </li>
+{{/each}}
+{{/each}}
+        </ul>
+      </section>
+{{/each}}
+    </article>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/views/repo.html
+++ b/views/repo.html
@@ -29,6 +29,7 @@
 {{#each apps}}
       <section>
         <h2>{{#if url}}{{#if is_url}}<a href="{{url}}" target="_blank" aria-hidden="true">{{url}}</a>{{else}}{{url}}{{/if}}{{else}}<em>No repository URL</em>{{/if}}{{#if url_hash}} <a href="/stats/{{url_hash}}"><span class="glyphicon glyphicon-bookmark" aria-hidden="true"></span></a>{{/if}} <span class="badge">{{count}}</span></h2>
+        {{#if url_hash}}<input type="text" class="form-control" readonly="readonly" value="{{url_hash}}">{{/if}}
         <ul class="list-group">
 {{#each this}}
 {{#each this}}

--- a/views/repo.html
+++ b/views/repo.html
@@ -21,6 +21,10 @@
       </div>
     </div>
     <article class="container">
+      <ol class="breadcrumb">
+        <li><a href="/stats">Stats</a></li>
+        <li class="active">Repository</li>
+      </ol>
       <h1>Application Deployments for Repository</h1>
 {{#each apps}}
       <section>

--- a/views/repo.html
+++ b/views/repo.html
@@ -21,7 +21,7 @@
       </div>
     </div>
     <article class="container">
-      <h1>Application Deployments by Repository</h1>
+      <h1>Application Deployments for Repository</h1>
 {{#each apps}}
       <section>
         <h2>{{#if url}}{{#if is_url}}<a href="{{url}}" target="_blank" aria-hidden="true">{{url}}</a>{{else}}{{url}}{{/if}}{{else}}<em>No repository URL</em>{{/if}}{{#if url_hash}} <a href="/stats/{{url_hash}}"><span class="glyphicon glyphicon-bookmark" aria-hidden="true"></span></a>{{/if}} <span class="badge">{{count}}</span></h2>

--- a/views/stats.html
+++ b/views/stats.html
@@ -24,7 +24,7 @@
       <h1>Application Deployments by Repository</h1>
 {{#each apps}}
       <section>
-        <h2>{{#if url}}{{#if is_url}}<a href="{{url}}" target="_blank" aria-hidden="true">{{url}}</a>{{else}}{{url}}{{/if}}{{else}}<em>No repository URL</em>{{/if}} <span class="badge">{{count}}</span></h2>
+        <h2>{{#if url}}{{#if is_url}}<a href="{{url}}" target="_blank">{{url}}</a>{{else}}{{url}}{{/if}}{{else}}<em>No repository URL</em>{{/if}}{{#if url_hash}} <a href="/stats/{{url_hash}}"><span class="glyphicon glyphicon-zoom-in" aria-hidden="true"></span></a>{{/if}} <span class="badge">{{count}}</span></h2>
         <ul class="list-group">
 {{#each this}}
 {{#each this}}

--- a/views/stats.html
+++ b/views/stats.html
@@ -21,6 +21,9 @@
       </div>
     </div>
     <article class="container">
+      <ol class="breadcrumb">
+        <li class="active">Stats</li>
+      </ol>
       <h1>Application Deployments by Repository</h1>
 {{#each apps}}
       <section>

--- a/views/stats.html
+++ b/views/stats.html
@@ -28,6 +28,7 @@
 {{#each apps}}
       <section>
         <h2>{{#if url}}{{#if is_url}}<a href="{{url}}" target="_blank">{{url}}</a>{{else}}{{url}}{{/if}}{{else}}<em>No repository URL</em>{{/if}}{{#if url_hash}} <a href="/stats/{{url_hash}}"><span class="glyphicon glyphicon-zoom-in" aria-hidden="true"></span></a>{{/if}} <span class="badge">{{count}}</span></h2>
+        {{#if url_hash}}<input type="text" class="form-control" readonly="readonly" value="{{url_hash}}">{{/if}}
         <ul class="list-group">
 {{#each this}}
 {{#each this}}


### PR DESCRIPTION
This pull request creates a per-repo metrics detail page. In its current iteration, this page is fairly useless as it simply provides a redundant view of the same data from the overview page. However, this pull request sets the groundwork for some upcoming features:
1. More detailed information about deployments of each specific repository
2. An HTML widget that can be embedded in tutorials, blog posts, etc.
3. An image widget that can be embedded in READMEs (similar to Travis CI build status images)

Some notes about this new feature:
- An MD5 hash is created of the repository URL and stored in each tracking event.
- A script is run on deployment to add hashes to previously tracked events (this can eventually be removed).
- A `by_repo_hash` map/reduce view indexes tracking events based on the repository URL hash.
- The URL hash is used in the page URL for the detail view, which is linked to from each repository instance on the overview page.
