### PR TITLE
endswith

### DIFF
--- a/app.js
+++ b/app.js
@@ -318,7 +318,7 @@ function authenticate() {
         else {
             var ibmer = false;
             _.each(verifiedEmail, function (email) {
-                if (email.toLowerCase().indexOf("ibm.com") !== -1) {
+                if (email.toLowerCase().endsWith("ibm.com")) {
                     ibmer = true;
                 }
             });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "postinstall": "./admin.js track && ./admin.js db put && ./admin.js ddoc put && ./admin.js clean repository_url_hash",
-    "start": "node app.js",
+    "start": "node --harmony_strings app.js",
     "test": "grunt"
   },
   "repository": {


### PR DESCRIPTION
- Changed start command from _node app.js_ to _node --harmony_strings app.js_ to take advantage of new endsWith string function
- Use endsWith() instead of indexOf for email check
- Modified postinstall commands to invoke node runtime explicitly to support deployments in non-Unix environments
