### PR TITLE
i1: capture service bindings and runtime environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ This web application includes code to track deployments to [IBM Bluemix](https:/
 * Space ID (`space_id`)
 * Application Version (`application_version`)
 * Application URIs (`application_uris`)
+* Labels of bound services
+* Number of instances for each bound service
 
-This data is collected from the `VCAP_APPLICATION` environment variable in IBM Bluemix and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Bluemix to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
+This data is collected from the `VCAP_APPLICATION` and `VCAP_SERVICES` environment variables in IBM Bluemix and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Bluemix to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
 
 ### Disabling Deployment Tracking
 
@@ -81,8 +83,10 @@ This web application includes code to track deployments to [IBM Bluemix](https:/
 * Space ID (`space_id`)
 * Application Version (`application_version`)
 * Application URIs (`application_uris`)
+* Labels of bound services
+* Number of instances for each bound service
 
-This data is collected from the `VCAP_APPLICATION` environment variable in IBM Bluemix and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Bluemix to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
+This data is collected from the `VCAP_APPLICATION` and `VCAP_SERVICES` environment variables in IBM Bluemix and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Bluemix to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
 
 ### Disabling Deployment Tracking
 

--- a/app.js
+++ b/app.js
@@ -539,7 +539,7 @@ function track(req, res) {
     event.application_uris = req.body.application_uris;
   }
   if ((req.body.bound_vcap_services) && (Object.keys(req.body.bound_vcap_services).length > 0)) {
-      event.bound_vcap_services = req.body.bound_vcap_services;     
+    event.bound_vcap_services = req.body.bound_vcap_services;     
   }
 
   var eventsDb = deploymentTrackerDb.use("events");

--- a/app.js
+++ b/app.js
@@ -538,6 +538,10 @@ function track(req, res) {
   if (req.body.application_uris) {
     event.application_uris = req.body.application_uris;
   }
+  if ((req.body.bound_vcap_services) && (Object.keys(req.body.bound_vcap_services).length > 0)) {
+      event.bound_vcap_services = req.body.bound_vcap_services;     
+  }
+
   var eventsDb = deploymentTrackerDb.use("events");
   eventsDb.insert(event, function (err) {
     if (err) {

--- a/app.js
+++ b/app.js
@@ -538,6 +538,9 @@ function track(req, res) {
   if (req.body.application_uris) {
     event.application_uris = req.body.application_uris;
   }
+  if (req.body.runtime) {
+    event.runtime = req.body.runtime;
+  }  
   if ((req.body.bound_vcap_services) && (Object.keys(req.body.bound_vcap_services).length > 0)) {
     event.bound_vcap_services = req.body.bound_vcap_services;     
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-tracker",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Tracks deployments of sample applications",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-tracker",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Tracks deployments of sample applications",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Add code to accept _optional_ `bound_vcap_services` payload, identifying which services are bound to the tracked application. It is expected that the `bound_vcap_services` property uses the following structure:

```
"bound_vcap_services": {
    "<service_label>": {
      "count": <instance_count>
    }
}
```

Each property `{ "<service_label>" : { "count" : <service_instance_count> }}` identifies the name of the service offering and the number of bound instances of that service.
Example: if two instances of the _cloudantNoSQLDB_ service and one instance of _rediscloud_ are bound to the tracked application, the payload would look as follows:

```
{
  "bound_vcap_services": {
    "cloudantNoSQLDB": {
      "count": 2
    },
    "rediscloud": {
      "count": 1
    }
  }
}
```

The `bound_vcap_services` property is only persisted in the repository if at least one service is bound to the application.
