### PR TITLE
i209: prevent badge/button caching

### DIFF
--- a/app.js
+++ b/app.js
@@ -465,7 +465,9 @@ app.get("/stats/:hash/badge.svg", forceSslIfNotLocal, function(req, res) {
     svgData.totalWidth = svgData.leftWidth + svgData.rightWidth;
     svgData.leftX = svgData.leftWidth / 2 + 1;
     svgData.rightX = svgData.leftWidth + svgData.rightWidth / 2 - 1;
-    res.set("Content-Type", "image/svg+xml");
+    res.set({"Content-Type": "image/svg+xml",
+             "Cache-Control": "no-cache",
+             "Expires": 0});
     res.render("badge.xml", svgData);
   });
 });
@@ -499,7 +501,9 @@ app.get("/stats/:hash/button.svg", forceSslIfNotLocal, function(req, res) {
     svgData.totalWidth = svgData.totalWidth + 48;
     svgData.leftX = svgData.leftX + 48;
     svgData.rightX = svgData.rightX + 48;
-    res.set("Content-Type", "image/svg+xml");
+    res.set({"Content-Type": "image/svg+xml",
+             "Cache-Control": "no-cache",
+             "Expires": 0});
     res.render("button.xml", svgData);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-tracker",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Tracks deployments of sample applications",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Added `"Cache-Control": "no-cache"` and `"Expires": 0` headers to `/stats/:hash/button.svg` and `/stats/:hash/badge.svg` API endpoint responses.