### PR TITLE
i168: capture VCAP_APPLICATION.application_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ There are a number of language-specific clients for the deployment tracker, incl
 This web application includes code to track deployments to [IBM Bluemix](https://www.bluemix.net/) and other Cloud Foundry platforms. The following information is sent to a [Deployment Tracker](https://github.com/cloudant-labs/deployment-tracker) service on each deployment:
 
 * Application Name (`application_name`)
+* Application GUID (`application_id`)
 * Space ID (`space_id`)
 * Application Version (`application_version`)
 * Application URIs (`application_uris`)

--- a/app.js
+++ b/app.js
@@ -533,6 +533,10 @@ function track(req, res) {
   if (req.body.application_name) {
     event.application_name = req.body.application_name;
   }
+  if (req.body.application_id) {
+    // VCAP_APPLICATION.application_id
+    event.application_id = req.body.application_id;
+  }  
   if (req.body.space_id) {
     event.space_id = req.body.space_id;
   }


### PR DESCRIPTION
If the tracking payload includes optional property `application_id` it will be stored in the deployment record. 