### PR TITLE
i228: track VCAP_APPLICATION.instance_index

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This web application includes code to track deployments to [IBM Bluemix](https:/
 
 * Application Name (`application_name`)
 * Application GUID (`application_id`)
+* Application instance index (`instance_index`)
 * Space ID (`space_id`)
 * Application Version (`application_version`)
 * Application URIs (`application_uris`)

--- a/app.js
+++ b/app.js
@@ -536,6 +536,10 @@ function track(req, res) {
   if (req.body.application_id) {
     // VCAP_APPLICATION.application_id
     event.application_id = req.body.application_id;
+  }
+  if (req.body.instance_index) {
+    // VCAP_APPLICATION.instance_index (Index number of the application instance, e.g. 0,1,...)
+    event.instance_index = req.body.instance_index;
   }  
   if (req.body.space_id) {
     event.space_id = req.body.space_id;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-tracker",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Tracks deployments of sample applications",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Accept optional payload property `instance_index`, identifying the application instance index for this tracking request.