### PR TITLE
i251: always set vcap_services property

### DIFF
--- a/app.js
+++ b/app.js
@@ -584,6 +584,9 @@ function track(req, res) {
   if ((req.body.bound_vcap_services) && (Object.keys(req.body.bound_vcap_services).length > 0)) {
     event.bound_vcap_services = req.body.bound_vcap_services;     
   }
+  else {
+    event.bound_vcap_services = [];
+  }
 
   var eventsDb = deploymentTrackerDb.use("events");
   eventsDb.insert(event, function (err) {

--- a/app.js
+++ b/app.js
@@ -585,7 +585,7 @@ function track(req, res) {
     event.bound_vcap_services = req.body.bound_vcap_services;     
   }
   else {
-    event.bound_vcap_services = [];
+    event.bound_vcap_services = {};
   }
 
   var eventsDb = deploymentTrackerDb.use("events");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-tracker",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Tracks deployments of sample applications",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
If  the tracking payload doesn't include any service information (`bound_vcap_services` is not set) the server will store an empty binding.