### PR TITLE
i253: ignore non-zero app instances

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -98,15 +98,20 @@ program
           views: {
             by_repo: {
               map: "function(doc) { if (doc.repository_url && doc.repository_url !== '') { " +
+                "if(! doc.hasOwnProperty('instance_index') || " +
+                "(doc.hasOwnProperty('instance_index') && doc.instance_index == '0')) { " +
                 "emit([doc.repository_url, doc.date_received.substring(0, 4), " +
                 "doc.date_received.substring(5, 7), doc.date_received.substring(8, 10), doc.space_id, " +
-                "doc.application_version]); } }",
+                "doc.application_version]); } } }",
               reduce: "_count",
             },
             by_repo_hash: {
-              map: "function(doc) { emit([doc.repository_url_hash, doc.repository_url, " +
+              map: "function(doc) { " +
+                "if(! doc.hasOwnProperty('instance_index') || " +
+                " (doc.hasOwnProperty('instance_index') && doc.instance_index == '0')) { " +
+                "emit([doc.repository_url_hash, doc.repository_url, " +
                 "doc.date_received.substring(0, 4), doc.date_received.substring(5, 7), " +
-                "doc.date_received.substring(8, 10), doc.space_id, doc.application_version]); }",
+                "doc.date_received.substring(8, 10), doc.space_id, doc.application_version]); } }",
               reduce: "_count",
             },
             apps_by_year_and_month: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-tracker",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Tracks deployments of sample applications",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Delivers #253.
Updated `by_repo` and `by_repo_hash` map definitions to exclude all deployment records that are _explicitly_ associated with an instance number greater than 0. 
Note that I used this comparison `doc.instance_index == '0'` on purpose to cover two data types at once, numeric and string. Even though all clients _should_ use a numeric data type [it is not enforced](https://github.com/IBM-Bluemix/cf-deployment-tracker-service/blob/master/app.js#L565)
