### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tracks deployments of sample applications",
   "main": "app.js",
   "scripts": {
-    "postinstall": "bower install --config.interactive=false --allow-root && ./admin.js track && ./admin.js db put && ./admin.js ddoc put && ./admin.js clean repository_url_hash && ./admin.js clean application_uris_array",
+    "postinstall": "bower install --config.interactive=false --allow-root && ./admin.js track && ./admin.js db put && ./admin.js ddoc put && ./admin.js clean application_uris_array",
     "start": "node app.js",
     "test": "grunt"
   },


### PR DESCRIPTION
Removed invocation of `./admin.js clean repository_url_hash` post-install step. In a local environment this task consumes several hundred megabytes because it fetches  198,726 documents. Upon completion of this task the number of documents that require cleansing does not decrease, which seems to indicate that those documents cannot be fixed. 